### PR TITLE
Fixes and improvements

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/BatteryMeterDrawable.java
+++ b/packages/SystemUI/src/com/android/systemui/BatteryMeterDrawable.java
@@ -64,6 +64,8 @@ public class BatteryMeterDrawable extends Drawable implements
     public static final String SHOW_PERCENT_SETTING = "status_bar_show_battery_percent";
     private static final String STATUS_BAR_CHARGE_COLOR =
             Settings.Secure.STATUS_BAR_CHARGE_COLOR;
+    private static final String BATTERY_LARGE_TEXT =
+            Settings.System.BATTERY_LARGE_TEXT;
 
     private static final boolean SINGLE_DIGIT_PERCENT = false;
 
@@ -75,10 +77,10 @@ public class BatteryMeterDrawable extends Drawable implements
     public static final int BATTERY_STYLE_PORTRAIT  = 0;
     public static final int BATTERY_STYLE_SOLID     = 1;
     public static final int BATTERY_STYLE_CIRCLE    = 2;
-    public static final int BATTERY_STYLE_HIDDEN    = 3;
-    public static final int BATTERY_STYLE_LANDSCAPE = 4;
-    public static final int BATTERY_STYLE_TEXT      = 5;
-    public static final int BATTERY_STYLE_BIGCIRCLE    = 6;
+    public static final int BATTERY_STYLE_BIGCIRCLE = 3;
+    public static final int BATTERY_STYLE_HIDDEN    = 4;
+    public static final int BATTERY_STYLE_LANDSCAPE = 5;
+    public static final int BATTERY_STYLE_TEXT      = 6;
 
     private final int[] mColors;
     private final int mIntrinsicWidth;
@@ -246,6 +248,9 @@ public class BatteryMeterDrawable extends Drawable implements
         mContext.getContentResolver().registerContentObserver(
                 CMSettings.System.getUriFor(CMSettings.System.STATUS_BAR_BATTERY_STYLE),
                 false, mSettingObserver);
+        mContext.getContentResolver().registerContentObserver(
+                Settings.System.getUriFor(BATTERY_LARGE_TEXT),
+                false, mSettingObserver);
         updateShowPercent();
         updateChargeColor();
         mBatteryController.addStateChangedCallback(this);
@@ -281,7 +286,7 @@ public class BatteryMeterDrawable extends Drawable implements
         mLevel = level;
         mPluggedIn = pluggedIn;
 
-        if (mStyle == BATTERY_STYLE_CIRCLE) {
+        if (mStyle == BATTERY_STYLE_CIRCLE || mStyle == BATTERY_STYLE_BIGCIRCLE) {
             animateCircleBattery(level, pluggedIn, charging);
         }
 
@@ -509,12 +514,6 @@ public class BatteryMeterDrawable extends Drawable implements
         mBoltDrawable = mBatteryDrawable.findDrawableByLayerId(R.id.battery_charge_indicator);
     }
 
-    private boolean isThemeApplied() {
-        final ThemeConfig themeConfig = ThemeConfig.getBootTheme(mContext.getContentResolver());
-        return themeConfig != null &&
-                !ThemeConfig.SYSTEM_DEFAULT.equals(themeConfig.getOverlayForStatusBar());
-    }
-
     private void checkBatteryMeterDrawableValid(Resources res, int style) {
         final int resId = getBatteryDrawableResourceForStyle(style);
         final Drawable batteryDrawable;
@@ -579,6 +578,7 @@ public class BatteryMeterDrawable extends Drawable implements
             case BATTERY_STYLE_LANDSCAPE:
                 return R.style.BatteryMeterViewDrawable_Landscape;
             case BATTERY_STYLE_CIRCLE:
+                return R.style.BatteryMeterViewDrawable_Circle;
             case BATTERY_STYLE_BIGCIRCLE:
                 return R.style.BatteryMeterViewDrawable_Circle;
 			case BATTERY_STYLE_SOLID:
@@ -614,16 +614,19 @@ public class BatteryMeterDrawable extends Drawable implements
         final float textSize;
         switch(mStyle) {
             case BATTERY_STYLE_CIRCLE:
-                textSize = widthDiv2 - mContext.getResources().getDisplayMetrics().density / 1.3f;
+                textSize = widthDiv2 * 1.0f;
                 break;
             case BATTERY_STYLE_LANDSCAPE:
                 textSize = widthDiv2 * 1.3f;
                 break;
             case BATTERY_STYLE_BIGCIRCLE:
-                textSize = widthDiv2 * 1.2f;
+                textSize = widthDiv2 * 1.3f;
+                break;
+            case BATTERY_STYLE_SOLID:
+                textSize = widthDiv2 * 1.0f;
                 break;
             default:
-                textSize = widthDiv2;
+                textSize = widthDiv2 * 0.9f;
                 break;
                 }
         mTextAndBoltPaint.setTextSize(textSize);

--- a/packages/SystemUI/src/com/android/systemui/qs/tiles/BatteryTile.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/tiles/BatteryTile.java
@@ -62,8 +62,8 @@ public class BatteryTile extends QSTile<QSTile.State> implements BatteryControll
     private int mBatteryStyle;
     private int mBatteryStyleTile;
 
-    public static final int BATTERY_STYLE_HIDDEN    = 3;
-    public static final int BATTERY_STYLE_TEXT      = 5;
+    public static final int BATTERY_STYLE_HIDDEN    = 4;
+    public static final int BATTERY_STYLE_TEXT      = 6;
 
     public BatteryTile(Host host) {
         super(host);

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/KeyguardStatusBarView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/KeyguardStatusBarView.java
@@ -577,7 +577,7 @@ public class KeyguardStatusBarView extends RelativeLayout
             case STATUS_BAR_SHOW_BATTERY_PERCENT:
                 mShowBatteryText = newValue == null ? false : Integer.parseInt(newValue) == 2;
                 mForceBatteryText = CMSettings.System.getInt(getContext().getContentResolver(),
-                        CMSettings.System.STATUS_BAR_BATTERY_STYLE, 0) == 5 ? true : false;
+                        CMSettings.System.STATUS_BAR_BATTERY_STYLE, 0) == 6 ? true : false;
                 mForceChargeBatteryText = Settings.Secure.getInt(getContext().getContentResolver(),
                         Settings.Secure.FORCE_CHARGE_BATTERY_TEXT, 1) == 1 ? true : false;
                 updateVisibilities();


### PR DESCRIPTION
Add lines to hopefully get large text to change on the fly
Set correct number for battery style in BatteryLevelTextView as new battery style was getting text forced to on.
Make circle battery percent a bit smaller when large text is turned on

Change-Id: I2c31ebe2b8298de525efd2780bcd77ad36b0aa61